### PR TITLE
Document usage of git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository contains code examples for [go-perun](https://github.com/hyperledger-labs/go-perun).
 
+## Setup
+
+Some of the examples presented in this repository make use of [git submodules](https://git-scm.com/book/de/v2/Git-Tools-Submodule). You will need to pull the submodules in order to use the respective examples:
+
+``` shell
+git submodule init
+git submodule update
+```
+
 ## License
 
 The source code in this repository is made available under the Apache License, Version 2.0.


### PR DESCRIPTION
Some examples use git submodules, which was previously undocumented. This commit adds the documentation necessary for a successful local setup.