### PR TITLE
fix(ci): fix the version of dfx for icp example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
             ${{ runner.os }}-go-
 
       - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.15.0
 
       - name: Pull ganache-cli image
         run: docker pull ${{ env.ganache-image }}
@@ -38,6 +40,8 @@ jobs:
 
           sleep 30
           go run ./
+
+          ./stopdfx.sh
       
       - name: Simple Client
         working-directory: simple-client

--- a/payment-channel-icp/go.sum
+++ b/payment-channel-icp/go.sum
@@ -13,10 +13,6 @@ github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/google/uuid v1.1.5 h1:kxhtnfFVi+rYdOALN0B3k9UT86zVJKfBimRaciULW4I=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/herumi/bls-eth-go-binary v1.36.1 h1:SfLjxbO1fWkKtKS7J3Ezd1/5QXrcaTZgWynxdSe10hQ=
-github.com/herumi/bls-eth-go-binary v1.36.1/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
-github.com/herumi/bls-go-binary v1.28.2 h1:F0AezsC0M1a9aZjk7g0l2hMb1F56Xtpfku97pDndNZE=
-github.com/herumi/bls-go-binary v1.28.2/go.mod h1:O4Vp1AfR4raRGwFeQpr9X/PQtncEicMoOe6BQt1oX0Y=
 github.com/herumi/bls-go-binary v1.35.1 h1:bCt7bZADjrpFY2sUw/Nx3FE3KuJBssLE4Y12dp4RSRo=
 github.com/herumi/bls-go-binary v1.35.1/go.mod h1:O4Vp1AfR4raRGwFeQpr9X/PQtncEicMoOe6BQt1oX0Y=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
This PR fix the bug #26  by fixate the deployed ICP testnet and also update the example to use icp-backend v0.1.0

Location: payment-channel-icp